### PR TITLE
Retry adding a job if the worker is busy

### DIFF
--- a/legion.asd
+++ b/legion.asd
@@ -21,10 +21,11 @@
                :vom)
   :components ((:module "src"
                 :components
-                ((:file "legion" :depends-on ("worker" "cluster"))
+                ((:file "legion" :depends-on ("worker" "cluster" "error"))
                  (:file "worker")
-                 (:file "cluster" :depends-on ("worker" "scheduler"))
-                 (:file "scheduler" :depends-on ("worker")))))
+                 (:file "cluster" :depends-on ("worker" "scheduler" "error"))
+                 (:file "scheduler" :depends-on ("worker"))
+                 (:file "error"))))
   :description "Simple worker threads with a queue."
   :long-description
   #.(with-open-file (stream (merge-pathnames

--- a/src/cluster.lisp
+++ b/src/cluster.lisp
@@ -78,7 +78,7 @@
   cluster)
 
 (define-condition cluster-queue-overflow (legion-error)
-  ((cluster :initarg cluster
+  ((cluster :initarg :cluster
             :type cluster))
   (:report (lambda (condition stream)
              (format stream "All queues in ~A are full" (slot-value condition 'cluster)))))

--- a/src/cluster.lisp
+++ b/src/cluster.lisp
@@ -12,6 +12,8 @@
                 :worker-idle-cond)
   (:import-from :legion.scheduler
                 :make-round-robin-scheduler)
+  (:import-from :legion.error
+                :legion-error)
   (:import-from :bordeaux-threads
                 :join-thread
                 :condition-wait
@@ -75,12 +77,29 @@
   (setf (cluster-status cluster) :shutdown)
   cluster)
 
+(define-condition cluster-queue-overflow (legion-error)
+  ((cluster :initarg cluster
+            :type cluster))
+  (:report (lambda (condition stream)
+             (format stream "All queues in ~A are full" (slot-value condition 'cluster)))))
+
 (defun add-job-to-cluster (cluster job)
   (when (eq (cluster-status cluster) :shutting)
     (return-from add-job-to-cluster nil))
-  (funcall (cluster-scheduler cluster)
-           (cluster-workers cluster)
-           job))
+  (let* ((workers (cluster-workers cluster))
+         (retry-count (length workers)))
+    (tagbody
+     retry
+       (let ((successp
+               (funcall (cluster-scheduler cluster)
+                        workers
+                        job)))
+         (unless successp
+           (decf retry-count)
+           (when (= retry-count 0)
+             (error 'cluster-queue-overflow :cluster cluster))
+           (go retry))))
+    t))
 
 (defun join-worker-threads (cluster)
   (unless (eq (cluster-status cluster) :running)

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -1,0 +1,7 @@
+(in-package :cl-user)
+(defpackage legion.error
+  (:use :cl)
+  (:export :legion-error))
+(in-package :legion.error)
+
+(define-condition legion-error (error) ())

--- a/src/legion.lisp
+++ b/src/legion.lisp
@@ -20,7 +20,10 @@
                 :stop-cluster
                 :kill-cluster
                 :add-job-to-cluster
-                :join-worker-threads)
+                :join-worker-threads
+                :cluster-queue-overflow)
+  (:import-from :legion.error
+                :legion-error)
   (:export :worker
            :make-worker
            :worker-status
@@ -38,7 +41,10 @@
            :start-cluster
            :stop-cluster
            :kill-cluster
-           :join-worker-threads))
+           :join-worker-threads
+
+           :legion-error
+           :cluster-queue-overflow))
 (in-package :legion)
 
 (defun add-job (to job)


### PR DESCRIPTION
Raise an error if all worker queues are full.

ref #1
